### PR TITLE
Left side truncating

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ This will produce the following html
 <p>123xxx</p>
 ```
 
-You can also truncate left side
+You can also truncate left side by using negative limit
 
 ```TypeScript
 @Component({
     ...
-    template: '<p>{{ "123456789" | truncate : 4 : "…" : 'left' }}</p>',
+    template: '<p>{{ "123456789" | truncate : -4 : "…" }}</p>',
     ...
 })
 ```

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You can also truncate left side
 ```TypeScript
 @Component({
     ...
-    template: '<p>{{ "123456789" | truncate : 4 : "…" | 'left' }}</p>',
+    template: '<p>{{ "123456789" | truncate : 4 : "…" : 'left' }}</p>',
     ...
 })
 ```

--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ This will produce the following html
 <p>123xxx</p>
 ```
 
+You can also truncate left side
+
+```TypeScript
+@Component({
+    ...
+    template: '<p>{{ "123456789" | truncate : 4 : "…" | 'left' }}</p>',
+    ...
+})
+```
+
+This will produce the following html
+
+```HTML
+<p>…6789</p>
+```
+
 ## Truncate by words
 
 Using TRUNCATE_PIPES also enable truncating by words

--- a/src/truncate-characters.pipe.spec.ts
+++ b/src/truncate-characters.pipe.spec.ts
@@ -33,11 +33,12 @@ describe('TruncateCharactersPipe', () => {
     expect(pipe.transform('', 3)).toEqual('');
   });
 
-  it('left position', () => {
-    expect(pipe.transform('123456789', 4, '…', 'left')).toEqual('…6789');
+  // Left side truncating
+  it('[left] position', () => {
+    expect(pipe.transform('123456789', -4, '…')).toEqual('…6789');
   });
 
-  it('left leaves empty string unchanged', () => {
-    expect(pipe.transform('', 3, '…', 'left')).toEqual('');
+  it('[left] leaves empty string unchanged', () => {
+    expect(pipe.transform('', -3, '…')).toEqual('');
   });
 });

--- a/src/truncate-characters.pipe.spec.ts
+++ b/src/truncate-characters.pipe.spec.ts
@@ -32,4 +32,12 @@ describe('TruncateCharactersPipe', () => {
   it('leaves empty string unchanged', () => {
     expect(pipe.transform('', 3)).toEqual('');
   });
+
+  it('left position', () => {
+    expect(pipe.transform('123456789', 4, '…', 'left')).toEqual('…6789');
+  });
+
+  it('left leaves empty string unchanged', () => {
+    expect(pipe.transform('', 3, '…', 'left')).toEqual('');
+  });
 });

--- a/src/truncate-characters.pipe.ts
+++ b/src/truncate-characters.pipe.ts
@@ -4,8 +4,9 @@ import { Pipe } from '@angular/core';
   name: 'truncate'
 })
 export class TruncateCharactersPipe {
-  transform(value: string, limit: number = 40, trail: String = '…', position: string = 'right'): string {
-    if (position === 'left') {
+  transform(value: string, limit: number = 40, trail: String = '…'): string {
+    if (limit < 0) {
+      limit *= -1;
       return value.length > limit ? trail + value.substring(value.length - limit, value.length) : value;
     } else {
       return value.length > limit ? value.substring(0, limit) + trail : value;

--- a/src/truncate-characters.pipe.ts
+++ b/src/truncate-characters.pipe.ts
@@ -4,7 +4,11 @@ import { Pipe } from '@angular/core';
   name: 'truncate'
 })
 export class TruncateCharactersPipe {
-  transform(value: string, limit: number = 40, trail: String = '…') : string {
-    return value.length > limit ? value.substring(0, limit) + trail : value;
+  transform(value: string, limit: number = 40, trail: String = '…', position: string = 'right'): string {
+    if (position === 'left') {
+      return value.length > limit ? trail + value.substring(value.length - limit, value.length) : value;
+    } else {
+      return value.length > limit ? value.substring(0, limit) + trail : value;
+    }
   }
 }

--- a/src/truncate-words.pipe.spec.ts
+++ b/src/truncate-words.pipe.spec.ts
@@ -9,7 +9,7 @@ describe('TruncateWordsPipe', () => {
     pipe = new TruncateWordsPipe();
   });
 
-  it('transforms "123 456789" to "123 456…"', () => {
+  it('transforms "123 456 789" to "123 456…"', () => {
     expect(pipe.transform('123 456 789', 2)).toEqual('123 456…');
   });
 
@@ -30,6 +30,19 @@ describe('TruncateWordsPipe', () => {
   });
 
   it('leaves empty string unchanged', () => {
+    expect(pipe.transform('', 3)).toEqual('');
+  });
+
+  // Left side truncating
+  it('[left] transforms "123 456 789" to "…456 789"', () => {
+    expect(pipe.transform('123 456 789', -2)).toEqual('…456 789');
+  });
+
+  it('[left] transforms "1234 5678 9" to "xxx9"', () => {
+    expect(pipe.transform('123 45678 9', -1, 'xxx')).toEqual('xxx9');
+  });
+
+  it('[left] leaves empty string unchanged', () => {
     expect(pipe.transform('', 3)).toEqual('');
   });
 });

--- a/src/truncate-words.pipe.ts
+++ b/src/truncate-words.pipe.ts
@@ -4,13 +4,18 @@ import { Pipe } from '@angular/core';
   name: 'words'
 })
 export class TruncateWordsPipe {
-  transform(value: string, limit: number = 40, trail: String = '…') : string {
+  transform(value: string, limit: number = 40, trail: String = '…'): string {
     let result = value;
 
     if (value) {
       let words = value.split(/\s+/);
-      if (words.length > limit) {
-        result = words.slice(0, limit).join(' ') + trail;
+      if (words.length > Math.abs(limit)) {
+        if (limit < 0) {
+          limit *= -1;
+          result = trail + words.slice(words.length - limit, words.length).join(' ');
+        } else {
+          result = words.slice(0, limit).join(' ') + trail;
+        }
       }
     }
 


### PR DESCRIPTION
I added left side char truncating. For example if you have IMG_20161101_23394.jpg I don't want it truncated to `IMG_201611...` but `..._23394.jpg`, since many images will have the first part of the name identical.