### PR TITLE
Add package metadata

### DIFF
--- a/projects/yellowspot/ng-truncate/package.json
+++ b/projects/yellowspot/ng-truncate/package.json
@@ -1,6 +1,13 @@
 {
   "name": "@yellowspot/ng-truncate",
   "version": "1.5.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yellowspot/ng2-truncate"
+  },
+  "bugs": {
+    "url": "https://github.com/yellowspot/ng2-truncate/issues"
+  },
   "peerDependencies": {
     "@angular/common": ">= 4.0.0",
     "@angular/core": ">= 4.0.0"

--- a/projects/yellowspot/ng-truncate/package.json
+++ b/projects/yellowspot/ng-truncate/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yellowspot/ng-truncate",
   "version": "1.5.1",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/yellowspot/ng2-truncate"


### PR DESCRIPTION
The repository's README already contains the "issues" badge, that contains a link to the github issues.
So I figured to link the repository and the issues page in the package.json, so that it appears on npmjs.com as well.